### PR TITLE
Error: req#logout requires a callback function

### DIFF
--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -6,9 +6,10 @@ router.get('/redirect', passport.authenticate('discord', {
     failureRedirect: '/forbidden',
     successRedirect: '/dashboard'
 }));
+
 router.get('/logout', (req, res) => {
     if(req.user) {
-        req.logout();
+        req.session.destroy();
         res.redirect('/');
     } else {
         res.redirect('/');


### PR DESCRIPTION
This will fix the following error - `Error: req#logout requires a callback function`, which occurs when trying to log out of the dashboard.

Replace the code below
```JS
router.get('/logout', (req, res) => {
    if(req.user) {
        req.logout();
        res.redirect('/');
    } else {
        res.redirect('/');
    }
});
```
With this
```JS
router.get('/logout', (req, res) => {
    if(req.user) {
        req.session.destroy();
        res.redirect('/');
    } else {
        res.redirect('/');
    }
});
```
Hope this will help someone :-)